### PR TITLE
(1.21) Make jam in jars inedible

### DIFF
--- a/src/data/java/net/dries007/tfc/data/providers/BuiltinFoods.java
+++ b/src/data/java/net/dries007/tfc/data/providers/BuiltinFoods.java
@@ -195,7 +195,7 @@ public class BuiltinFoods extends DataManagerProvider<FoodDefinition> implements
         add(Food.COOKED_CAMELIDAE, ofFood(2, 0, 2.25f).protein(2.5f));
 
         add(TFCTags.Items.SEALED_PRESERVES, ofFood(0, 0, 0, 5f), false);
-        add(TFCTags.Items.PRESERVES, ofFood(0, 0, 0, 5f).fruit(0.75f), true);
+        add(TFCTags.Items.PRESERVES, ofFood(1, 0, 5f).fruit(0.75f), true);
         add(TFCTags.Items.JAM, ofFood(1, 0, 5).fruit(0.75f), true);
         add(TFCTags.Items.SALADS, of(4.5f), true);
         add(TFCTags.Items.SOUPS, of(4.5f), true);

--- a/src/data/java/net/dries007/tfc/data/providers/BuiltinFoods.java
+++ b/src/data/java/net/dries007/tfc/data/providers/BuiltinFoods.java
@@ -195,7 +195,7 @@ public class BuiltinFoods extends DataManagerProvider<FoodDefinition> implements
         add(Food.COOKED_CAMELIDAE, ofFood(2, 0, 2.25f).protein(2.5f));
 
         add(TFCTags.Items.SEALED_PRESERVES, ofFood(0, 0, 0, 5f), false);
-        add(TFCTags.Items.PRESERVES, ofFood(1, 0, 5f).fruit(0.75f), true);
+        add(TFCTags.Items.PRESERVES, ofFood(0, 0, 0, 5f).fruit(0.75f), false);
         add(TFCTags.Items.JAM, ofFood(1, 0, 5).fruit(0.75f), true);
         add(TFCTags.Items.SALADS, of(4.5f), true);
         add(TFCTags.Items.SOUPS, of(4.5f), true);


### PR DESCRIPTION
Jam in jars is currently edible, which is an unintended change from 1.20. It gives no hunger or nutrution, and does not give the jar back.